### PR TITLE
Added new interceptor that invokes a flow (or any kind of IS) service

### DIFF
--- a/src/main/java/org/wmaop/flow/MockManager.java
+++ b/src/main/java/org/wmaop/flow/MockManager.java
@@ -17,6 +17,7 @@ import org.wmaop.chainprocessor.AOPChainProcessor;
 import org.wmaop.interceptor.mock.canned.CannedResponseInterceptor;
 import org.wmaop.interceptor.mock.canned.CannedResponseInterceptor.ResponseSequence;
 import org.wmaop.interceptor.mock.exception.ExceptionInterceptor;
+import org.wmaop.interceptor.mock.isservice.FlowServiceDelegatingInterceptor;
 import org.wmaop.util.pipeline.StructureConverter;
 
 import com.wm.app.b2b.server.ServiceException;
@@ -32,6 +33,8 @@ public class MockManager extends AbstractFlowManager {
 	public static final String RESPONSE = "response";
 	public static final String INTERCEPT_POINT = "interceptPoint";
 	public static final String SERVICE_NAME = "serviceName";
+	public static final String INTERFACE = "interface";
+	public static final String MOCK_SERVICE_NAME = "mockServiceName";
 	public static final String CONDITION = "condition";
 	public static final String EXCEPTION = "exception";
 	public static final String SCOPE = "scope";
@@ -197,4 +200,23 @@ public class MockManager extends AbstractFlowManager {
 			throw new ServiceException(e);
 		}
 	}
+	
+	@SuppressWarnings("unchecked")
+	public void registerFlowServiceMock(IData pipeline) throws ServiceException {
+		IDataCursor pipelineCursor = pipeline.getCursor();
+		String adviceId = IDataUtil.getString(pipelineCursor, ADVICE_ID);
+		String interceptPoint = IDataUtil.getString(pipelineCursor, INTERCEPT_POINT);
+		String serviceName = IDataUtil.getString(pipelineCursor, SERVICE_NAME);
+		String ifcname = IDataUtil.getString(pipelineCursor, INTERFACE);
+		String mockServiceName = IDataUtil.getString(pipelineCursor, MOCK_SERVICE_NAME);
+		String pipelineCondition = IDataUtil.getString(pipelineCursor, CONDITION);
+		String calledBy = IDataUtil.getString(pipelineCursor, CALLED_BY);
+		pipelineCursor.destroy();
+
+		mandatory(pipeline, "{0} must exist when creating a flow service mock", ADVICE_ID, INTERCEPT_POINT, SERVICE_NAME, INTERFACE, MOCK_SERVICE_NAME);
+		
+		Interceptor interceptor = new FlowServiceDelegatingInterceptor(ifcname, mockServiceName);
+		registerInterceptor(adviceId, getRemit(pipeline), interceptPoint.toUpperCase(), serviceName, pipelineCondition, interceptor, calledBy);
+	}
+
 }

--- a/src/main/java/org/wmaop/interceptor/mock/isservice/FlowServiceDelegatingInterceptor.java
+++ b/src/main/java/org/wmaop/interceptor/mock/isservice/FlowServiceDelegatingInterceptor.java
@@ -1,0 +1,54 @@
+package org.wmaop.interceptor.mock.isservice;
+
+import java.util.Map;
+
+import org.wmaop.aop.interceptor.FlowPosition;
+import org.wmaop.aop.interceptor.InterceptResult;
+import org.wmaop.aop.interceptor.InterceptionException;
+import org.wmaop.interceptor.BaseInterceptor;
+
+import com.wm.data.IData;
+import com.wm.data.IDataUtil;
+import com.wm.app.b2b.server.Service;
+
+public class FlowServiceDelegatingInterceptor extends BaseInterceptor {
+
+	public static final String MAP_INTERFACE_NAME = "ifcname";
+
+	private final String ifcname;
+	private final String serviceName;
+
+	public FlowServiceDelegatingInterceptor(String ifcname, String serviceName) {
+		super("IntegrationServerService:"+ifcname+":"+serviceName);
+		this.serviceName = serviceName;
+		this.ifcname = ifcname;
+	}
+
+	@Override
+	public InterceptResult intercept(FlowPosition flowPosition, IData idata) {
+		invokeCount++;
+		sendPost(idata);
+		return InterceptResult.TRUE;
+	}
+
+	@Override
+	public String getName() {
+		return serviceName;
+	}
+	
+	private void sendPost(IData idata) {
+		try {
+			IData output = Service.doInvoke(ifcname, serviceName, idata);
+			IDataUtil.merge(output, idata);
+		} catch (Exception e) {
+			throw new InterceptionException("Error while executing flow service " +
+					ifcname + ":" + serviceName, e);
+		}
+	}
+
+	@Override
+	protected void addMap(Map<String, Object> am) {
+		am.put(MAP_TYPE, "FlowServiceDelegatingInterceptor");
+		am.put(MAP_INTERFACE_NAME, ifcname);
+	}
+}


### PR DESCRIPTION
This new interceptor can invoke an IS service instead of the one being intercepted. This allows to use a more complex business logic when compared to scenarios, while simplifying developers's workflow (since they don't need to learn how to define an scenario; they just need to know how to develop a plain old flow service).